### PR TITLE
Added a new Cumulative Summary for Belief Arrays

### DIFF
--- a/medical_diagnosis/Model.py
+++ b/medical_diagnosis/Model.py
@@ -153,22 +153,29 @@ class MedicalModel(Model):
         publish__belief_arrays(self)
 
         # placeholder = [1. for x in range(5)]
+        committee_summary = [0. for x in range(5)]
         for doctor in self.schedule.agents:
             # placeholder *= numpy.multiply(placeholder, doctor.belief_array)
-            placeholder += numpy.multiply([1. for x in range(5)], doctor.belief_array)
+            # taking in consideration both certainties and uncertainties
+            # we consider values under 0.5 as a doctor's uncertainty in an arguments
+            # hence it will negatively affect the committee belief array summary
+            # ref: a more detailed discussion has been added in the report
+            placeholder = [-x if x < 0.5 else x for x in doctor.belief_array]
+            #print('placeholder: ', placeholder)
+            committee_summary = [sum(x) for x in zip(committee_summary, placeholder)]
 
-        probabilities = softmax(placeholder)
-        print('placeholder array: ', softmax(placeholder))
-        print('zika array: ', self.ZIKA_ARRAY)
-        print('chikv array: ', self.CHIKV_ARRAY)
+        probabilities = softmax(committee_summary)
+        print('softmax: ', probabilities)
+        # print('zika array: ', self.ZIKA_ARRAY)
+        # print('chikv array: ', self.CHIKV_ARRAY)
 
-        odds_zika = sum(numpy.multiply(self.ZIKA_ARRAY, probabilities))/sum(probabilities)
-        odds_chikv = sum(numpy.multiply(self.CHIKV_ARRAY, probabilities))/sum(probabilities)
+        probability_zika = sum(numpy.multiply(self.ZIKA_ARRAY, probabilities))/sum(probabilities)
+        probability_chikv = sum(numpy.multiply(self.CHIKV_ARRAY, probabilities))/sum(probabilities)
 
-        print('odds zika: ', "{0:.2f}".format(round(odds_zika, 2)))
-        print('odds chikv: ', "{0:.2f}".format(round(odds_chikv, 2)))
+        print('odds zika: ', "{0:.2f}".format(round(probability_zika, 2)))
+        print('odds chikv: ', "{0:.2f}".format(round(probability_chikv, 2)))
 
-        if odds_zika > odds_chikv:
+        if probability_zika > probability_chikv:
             print(self.LIST_OF_DISEASES['X'])
         else:
             print(self.LIST_OF_DISEASES['Y'])


### PR DESCRIPTION
Committee Decision Pseudo Code:

* Calculate cumulative summary from the committee, that is, a cumulative summary of all the belief arrays(doctors) in the committee. **New Addition: Instead of accounting all the probabilities towards a cumulative summary, we take belief array values above 0.5 as support towards a particular argument and incorporate it positively in the cumulative summary. Whereas belief array values below 0.5 are used to penalize the confidence of the committee in that particular argument, which is reflected in the cumulative summary**. 

```  
for doctor in self.schedule.agents:
        placeholder = [-x if x < 0.5 else x for x in doctor.belief_array]
        committee_summary = [sum(x) for x in zip(committee_summary, placeholder)]
```

* We further pass this cumulative summary array through a softmax function, to ensure that the sum of probabilities for each argument supporting a certain conclusion doesn't exceed 1.
* We calculate probability of a conclusion X from all the possible conclusions, by summing up probabilities in cumulative summary array supporting conclusion X and normalizing it by sum of all the probabilities in the residual belief array.
* We compare probabilities for all the conclusions in order to decide which is the most likely conclusion from the committee of doctors.